### PR TITLE
Rename cm to chaos-monkey-engine

### DIFF
--- a/chaosmonkey/cm/cm.py
+++ b/chaosmonkey/cm/cm.py
@@ -6,7 +6,7 @@ from chaosmonkey.engine.app import configure_engine, shutdown_engine
 from chaosmonkey.api.app import flask_app
 
 
-@click.command()
+@click.command(name='chaos-monkey-engine')
 @click.option("--port", "-p", default=5000, help="Port used to expose the CM API. Default 5000")
 @click.option("--timezone", "-t", default="Europe/Madrid", help="Timezone to configure the scheduler. Default 'Europe/Madrid'")
 @click.option("--database-uri", "-d", required=True, help="SQLAlchemy database uri")

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -8,11 +8,11 @@ Docker container
 
 Build the container with Docker 1.12+::
 
-    docker build -t cm .
+    docker build -t chaos-monkey-engine .
 
-Then, you can run the container as the ``cm`` command. E.g::
+Then, you can run the container as the ``chaos-monkey-engine`` command. E.g::
 
-    docker run --rm cm --help
+    docker run --rm chaos-monkey-engine --help
 
 Python package
 **************
@@ -27,7 +27,7 @@ Install the engine::
 
     pip install .
 
-Now you have the ``cm`` command on your path::
+Now you have the ``chaos-monkey-engine`` command on your path::
 
-    cm --help
+    chaos-monkey-engine --help
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -29,8 +29,8 @@ Get your engine up and running
 
 Build and run the Docker container::
 
-    docker build -t cm .
-    docker run --rm -p 5000:5000 -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_DEFAULT_REGION -ti cm
+    docker build -t chaos-monkey-engine .
+    docker run --rm -p 5000:5000 -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_DEFAULT_REGION -ti chaos-monkey-engine
 
 The Chaos Monkey Engine should be now listening in port 5000 TCP and ready to attack the machines in your AWS infrastructure.
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -3,9 +3,9 @@
 Usage
 =====
 
-Running ``cm --help`` shows the usage information::
+Running ``chaos-monkey-engine --help`` shows the usage information::
 
-  Usage: cm [OPTIONS]
+  Usage: chaos-monkey-engine [OPTIONS]
 
     Chaos Monkey Engine command line utility
 
@@ -28,5 +28,5 @@ The Docker container has a default ``CMD`` directive that sets these sane defaul
 
 For example, to launch the server on port 5000 TCP as a foreground process, passing AWS credentials::
 
-  docker run --rm -p 5000:5000 -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_DEFAULT_REGION -ti cm
+  docker run --rm -p 5000:5000 -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_DEFAULT_REGION -ti chaos-monkey-engine
 

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,6 @@ setup(name='chaosmonkey',
       include_package_data=True,
       entry_points='''
         [console_scripts]
-        cm=chaosmonkey.cm:cm
+        chaos-monkey-engine=chaosmonkey.cm:cm
         ''',
      )


### PR DESCRIPTION
Rename the Click command to *chaos-monkey-engine* so that it can be more coherent with the Docker image name (`bbvalabs/chaos-monkey-engine`)